### PR TITLE
Support GNOME Shell 50

### DIFF
--- a/persian-calendar@iamrezamousavi.gmail.com/calendar.js
+++ b/persian-calendar@iamrezamousavi.gmail.com/calendar.js
@@ -2,6 +2,7 @@
 /* exported Calendar*/
 
 import Clutter from 'gi://Clutter';
+import GDesktopEnums from 'gi://GDesktopEnums';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
@@ -16,6 +17,7 @@ import {getDayAccessibleName} from './utils/dateformat.js';
 import {toPersianDigit} from './utils/numbers.js';
 
 const SHOW_WEEKDATE_KEY = 'show-weekdate';
+const WEEK_START_DAY_KEY = 'week-start-day';
 const USE_PERSIAN_WEEKDAY = 'calendar-persian-weekday';
 const USE_PERSIAN_NUMBER = 'calendar-persian-number';
 
@@ -76,9 +78,6 @@ export const Calendar = GObject.registerClass({
     Signals: {'selected-date-changed': {param_types: [GLib.DateTime.$gtype]}},
 }, class Calendar extends St.Widget {
     _init(settings) {
-        // this._weekStart = Shell.util_get_week_start();
-        this._weekStart = 6;
-
         this.settings = settings;
         this.settings.connect(`changed::${USE_PERSIAN_WEEKDAY}`, this._onSettingsChange.bind(this));
         this.settings.connect(`changed::${USE_PERSIAN_NUMBER}`, this._onSettingsChange.bind(this));
@@ -86,7 +85,14 @@ export const Calendar = GObject.registerClass({
         this.usePersianDay = this.settings.get_boolean(USE_PERSIAN_NUMBER);
 
         this._settings = new Gio.Settings({schema_id: 'org.gnome.desktop.calendar'});
+        try {
+            this._settings.get_enum(WEEK_START_DAY_KEY);
+            this._settings.connect(`changed::${WEEK_START_DAY_KEY}`, this._onSettingsChange.bind(this));
+        } catch {
+            // week-start-day added in GNOME 50
+        }
         this._settings.connect(`changed::${SHOW_WEEKDATE_KEY}`, this._onSettingsChange.bind(this));
+        this._weekStart = this._getWeekStartDay();
         this._useWeekdate = this._settings.get_boolean(SHOW_WEEKDATE_KEY);
 
         /**
@@ -119,6 +125,18 @@ export const Calendar = GObject.registerClass({
         });
 
         this._buildHeader();
+    }
+
+    _getWeekStartDay() {
+        try {
+            const weekStartDay = this._settings.get_enum(WEEK_START_DAY_KEY);
+            if (weekStartDay === GDesktopEnums.Weekday.DEFAULT)
+                return 6;
+
+            return weekStartDay % 7;
+        } catch {
+            return 6;
+        }
     }
 
     setEventSource(_eventSource) {
@@ -278,6 +296,7 @@ export const Calendar = GObject.registerClass({
     _onSettingsChange() {
         this.usePersianWeekday = this.settings.get_boolean(USE_PERSIAN_WEEKDAY);
         this.usePersianDay = this.settings.get_boolean(USE_PERSIAN_NUMBER);
+        this._weekStart = this._getWeekStartDay();
         this._useWeekdate = this._settings.get_boolean(SHOW_WEEKDATE_KEY);
         this._buildHeader();
         this._rebuildCalendar();

--- a/persian-calendar@iamrezamousavi.gmail.com/metadata.json
+++ b/persian-calendar@iamrezamousavi.gmail.com/metadata.json
@@ -3,11 +3,11 @@
   "original-authors": "Reza Mousavi",
   "description": "Fork of Gnome Calendar extension with Persian taste",
   "shell-version": [
-    "45", "46", "47", "48", "49"
+    "45", "46", "47", "48", "49", "50"
   ],
   "url": "https://github.com/IamRezaMousavi/persian-gnome-calendar-extension",
   "uuid": "persian-calendar@iamrezamousavi.gmail.com",
   "settings-schema": "org.gnome.shell.extensions.PersianCalendar",
   "gettext-domain": "persian-calendar@iamrezamousavi.gmail.com",
-  "version": 31
+  "version": 32
 }


### PR DESCRIPTION
## Summary

- Adds GNOME Shell **50** to `shell-version` and bumps extension version to **32**
- Reads the new `org.gnome.desktop.calendar` **`week-start-day`** setting (GNOME 50)
- Keeps **Saturday (6)** as the default when the setting is unset or unavailable
- Uses `try/catch` for older shells where the key does not exist

## Test plan

- [ ] Install on GNOME Shell 50 and enable the extension
- [ ] Confirm the calendar panel opens without errors
- [ ] Change **Settings → Date & Time → Calendar → Week starts on** and verify the grid updates
- [ ] Verify extension still works on GNOME 49 with Saturday as week start